### PR TITLE
Fix duplicate items when Fastest Delivery sort is selected

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -204,19 +204,19 @@ def get_products_api(
                     stmt = stmt.join(ProductDeliveryLink).join(DeliveryOption).order_by(
                         cast(ColumnElement[int], DeliveryOption.estimated_days_min).asc(),
                         cast(ColumnElement[float], Product.price).asc()
-                    )
+                    ).distinct()
                 else:
                     stmt = stmt.join(ProductDeliveryLink).join(DeliveryOption).order_by(
                         cast(ColumnElement[int], DeliveryOption.estimated_days_min).asc(),
                         cast(ColumnElement[float], Product.price).asc()
-                    )
+                    ).distinct()
             else:
                 stmt = stmt.order_by(cast(ColumnElement, Product.created_at).desc())
         else:
             stmt = stmt.join(ProductDeliveryLink).join(DeliveryOption).order_by(
                 cast(ColumnElement[int], DeliveryOption.estimated_days_min).asc(),
                 cast(ColumnElement[float], Product.price).asc()
-            )
+            ).distinct()
     elif sort == "price_asc":
         stmt = stmt.order_by(cast(ColumnElement[float], Product.price).asc())
     elif sort == "price_desc":


### PR DESCRIPTION
Fixes #16

## Problem
Duplicate items were shown when 'Fastest Delivery' sort was chosen. This happened because products can have multiple delivery options, and the join with ProductDeliveryLink and DeliveryOption tables created duplicate rows.

## Solution
Added `.distinct()` to all delivery_fastest sort queries to ensure each product appears only once in the results.

## Testing
- All backend tests pass ✅
- All frontend builds pass ✅  
- All E2E tests pass ✅
- CI checks pass ✅