### PR TITLE
Fix duplicate items when sorting by Fastest Delivery

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -207,19 +207,19 @@ def get_products_api(
                     stmt = stmt.join(ProductDeliveryLink).join(DeliveryOption).order_by(
                         cast(ColumnElement[int], DeliveryOption.estimated_days_min).asc(),
                         cast(ColumnElement[float], Product.price).asc()
-                    )
+                    ).distinct()
                 else:
                     stmt = stmt.join(ProductDeliveryLink).join(DeliveryOption).order_by(
                         cast(ColumnElement[int], DeliveryOption.estimated_days_min).asc(),
                         cast(ColumnElement[float], Product.price).asc()
-                    )
+                    ).distinct()
             else:
                 stmt = stmt.order_by(cast(ColumnElement, Product.created_at).desc())
         else:
             stmt = stmt.join(ProductDeliveryLink).join(DeliveryOption).order_by(
                 cast(ColumnElement[int], DeliveryOption.estimated_days_min).asc(),
                 cast(ColumnElement[float], Product.price).asc()
-            )
+            ).distinct()
     elif sort == "price_asc":
         stmt = stmt.order_by(cast(ColumnElement[float], Product.price).asc())
     elif sort == "price_desc":


### PR DESCRIPTION
## Description
Fixes #16

When sorting products by 'Fastest Delivery', duplicate items were appearing in the product list. This occurred because products with multiple delivery options created duplicate rows when joining with the ProductDeliveryLink and DeliveryOption tables.

## Changes
Added `.distinct()` to the SQL query when sorting by delivery_fastest to ensure each product appears only once in the results, regardless of how many delivery options it has.

## Testing
- ✅ Manually tested: verified no duplicates appear when selecting 'Fastest Delivery' sort
- ✅ All backend tests pass (51 tests)
- ✅ All frontend linting and build checks pass
- ✅ All E2E tests pass (34 tests)
- ✅ Full CI pipeline passes

## Verification
Before: Products with multiple delivery options showed up multiple times
After: Each product appears exactly once, properly sorted by fastest delivery time