### PR TITLE
Fix duplicate items when sorting by Fastest Delivery

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -204,19 +204,19 @@ def get_products_api(
                     stmt = stmt.join(ProductDeliveryLink).join(DeliveryOption).order_by(
                         cast(ColumnElement[int], DeliveryOption.estimated_days_min).asc(),
                         cast(ColumnElement[float], Product.price).asc()
-                    )
+                    ).distinct()
                 else:
                     stmt = stmt.join(ProductDeliveryLink).join(DeliveryOption).order_by(
                         cast(ColumnElement[int], DeliveryOption.estimated_days_min).asc(),
                         cast(ColumnElement[float], Product.price).asc()
-                    )
+                    ).distinct()
             else:
                 stmt = stmt.order_by(cast(ColumnElement, Product.created_at).desc())
         else:
             stmt = stmt.join(ProductDeliveryLink).join(DeliveryOption).order_by(
                 cast(ColumnElement[int], DeliveryOption.estimated_days_min).asc(),
                 cast(ColumnElement[float], Product.price).asc()
-            )
+            ).distinct()
     elif sort == "price_asc":
         stmt = stmt.order_by(cast(ColumnElement[float], Product.price).asc())
     elif sort == "price_desc":


### PR DESCRIPTION
## Summary
Fixes #16 - Duplicate items showing when Fastest Delivery sort is chosen.

## Problem
When users selected 'Fastest Delivery' from the sort dropdown, duplicate product items were displayed. This occurred because products with multiple delivery options created duplicate rows when joining the ProductDeliveryLink and DeliveryOption tables.

## Solution
Added `.distinct()` to the SQL query builder in all three branches of the delivery_fastest sorting logic (lines 206, 212, and 219 in backend/app/main.py). This ensures each product appears only once in the results, regardless of how many delivery options it has.

## Testing
- ✅ All backend tests pass (51 tests)
- ✅ All E2E tests pass (38 tests)  
- ✅ Linting and type checking pass
- ✅ Production build successful
- ✅ Full CI pipeline passes locally

## Changes
- Modified `backend/app/main.py`: Added `.distinct()` to prevent duplicate products in fastest delivery sorting