### PR TITLE
Fix duplicate items when sorting by Fastest Delivery

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -207,19 +207,19 @@ def get_products_api(
                     stmt = stmt.join(ProductDeliveryLink).join(DeliveryOption).order_by(
                         cast(ColumnElement[int], DeliveryOption.estimated_days_min).asc(),
                         cast(ColumnElement[float], Product.price).asc()
-                    )
+                    ).distinct()
                 else:
                     stmt = stmt.join(ProductDeliveryLink).join(DeliveryOption).order_by(
                         cast(ColumnElement[int], DeliveryOption.estimated_days_min).asc(),
                         cast(ColumnElement[float], Product.price).asc()
-                    )
+                    ).distinct()
             else:
                 stmt = stmt.order_by(cast(ColumnElement, Product.created_at).desc())
         else:
             stmt = stmt.join(ProductDeliveryLink).join(DeliveryOption).order_by(
                 cast(ColumnElement[int], DeliveryOption.estimated_days_min).asc(),
                 cast(ColumnElement[float], Product.price).asc()
-            )
+            ).distinct()
     elif sort == "price_asc":
         stmt = stmt.order_by(cast(ColumnElement[float], Product.price).asc())
     elif sort == "price_desc":


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/amp-demo/issues/35

## Problem
Duplicate items were showing when the "Fastest Delivery" sort option was selected, even when a specific category was chosen.

## Root Cause
The issue was caused by joining  and  tables without using . When a product has multiple delivery options, the join would create multiple rows for the same product.

## Solution
Added  to all "Fastest Delivery" sorting queries in the backend to ensure each product appears only once in the results.

## Testing
- All backend tests pass (51 tests)
- All E2E tests pass (34 tests)
- Linting and type checking pass
- Full CI pipeline passes locally

The fix ensures that each product is displayed exactly once when sorted by delivery speed, while maintaining the correct sorting order.