### PR TITLE
Fix duplicate items when Fastest Delivery sort is chosen

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -231,6 +231,7 @@ def get_products_api(
                             ).asc(),
                             cast(ColumnElement[float], Product.price).asc(),
                         )
+                        .distinct()
                     )
                 else:
                     stmt = (
@@ -242,6 +243,7 @@ def get_products_api(
                             ).asc(),
                             cast(ColumnElement[float], Product.price).asc(),
                         )
+                        .distinct()
                     )
             else:
                 stmt = stmt.order_by(cast(ColumnElement, Product.created_at).desc())
@@ -253,6 +255,7 @@ def get_products_api(
                     cast(ColumnElement[int], DeliveryOption.estimated_days_min).asc(),
                     cast(ColumnElement[float], Product.price).asc(),
                 )
+                .distinct()
             )
     elif sort == "price_asc":
         stmt = stmt.order_by(cast(ColumnElement[float], Product.price).asc())

--- a/backend/tests/api/test_products.py
+++ b/backend/tests/api/test_products.py
@@ -351,3 +351,17 @@ def test_product_search_functionality(client: TestClient, session: Session):
     else:
         # Search not implemented, skip this test
         pytest.skip("Search functionality not implemented")
+
+
+def test_delivery_fastest_sort_no_duplicates(client: TestClient):
+    """Test that delivery_fastest sort does not return duplicate products"""
+    response = client.get("/products?sort=delivery_fastest")
+    assert response.status_code == 200
+    products = response.json()
+
+    product_ids = [p["id"] for p in products]
+    unique_product_ids = set(product_ids)
+
+    assert len(product_ids) == len(unique_product_ids), (
+        f"Found {len(product_ids) - len(unique_product_ids)} duplicate products"
+    )


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/amp-demo/issues/35

## Changes
- Added `.distinct()` to all `delivery_fastest` sort queries to eliminate duplicate products
- Products were appearing multiple times due to JOIN operations with `ProductDeliveryLink` and `DeliveryOption` tables
- Added test case `test_delivery_fastest_sort_no_duplicates` to verify no duplicates are returned

## Testing
- All backend tests pass (52 passed)
- All E2E tests pass (34 passed)
- Full CI pipeline passes (linting, type checking, build, tests)

## Root Cause
When sorting by fastest delivery, the query joins the Product table with ProductDeliveryLink and DeliveryOption tables. Since a product can have multiple delivery options, the JOIN was creating multiple rows per product, resulting in duplicates in the API response.