### PR TITLE
Fix duplicate items when sorting by Fastest Delivery

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -231,6 +231,7 @@ def get_products_api(
                             ).asc(),
                             cast(ColumnElement[float], Product.price).asc(),
                         )
+                        .distinct()
                     )
                 else:
                     stmt = (
@@ -242,6 +243,7 @@ def get_products_api(
                             ).asc(),
                             cast(ColumnElement[float], Product.price).asc(),
                         )
+                        .distinct()
                     )
             else:
                 stmt = stmt.order_by(cast(ColumnElement, Product.created_at).desc())
@@ -253,6 +255,7 @@ def get_products_api(
                     cast(ColumnElement[int], DeliveryOption.estimated_days_min).asc(),
                     cast(ColumnElement[float], Product.price).asc(),
                 )
+                .distinct()
             )
     elif sort == "price_asc":
         stmt = stmt.order_by(cast(ColumnElement[float], Product.price).asc())


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/amp-demo/issues/35

## Problem
When sorting by 'Fastest Delivery', duplicate items were appearing in the product list. This occurred because the SQL query was joining the ProductDeliveryLink and DeliveryOption tables without deduplicating results. Since products can have multiple delivery options, each join created a separate row for the same product.

## Solution
Added `.distinct()` to all three code paths in the delivery_fastest sorting logic to ensure each product appears only once in the results.

## Testing
- ✅ All backend tests pass (51 tests)
- ✅ All E2E tests pass (34 tests)
- ✅ All CI checks pass (format, lint, type check, build)
- ✅ Verified locally that products no longer duplicate when sorting by Fastest Delivery