### PR TITLE
Fix duplicate items when Fastest Delivery sort is chosen

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -231,6 +231,7 @@ def get_products_api(
                             ).asc(),
                             cast(ColumnElement[float], Product.price).asc(),
                         )
+                        .distinct()
                     )
                 else:
                     stmt = (
@@ -242,6 +243,7 @@ def get_products_api(
                             ).asc(),
                             cast(ColumnElement[float], Product.price).asc(),
                         )
+                        .distinct()
                     )
             else:
                 stmt = stmt.order_by(cast(ColumnElement, Product.created_at).desc())
@@ -253,6 +255,7 @@ def get_products_api(
                     cast(ColumnElement[int], DeliveryOption.estimated_days_min).asc(),
                     cast(ColumnElement[float], Product.price).asc(),
                 )
+                .distinct()
             )
     elif sort == "price_asc":
         stmt = stmt.order_by(cast(ColumnElement[float], Product.price).asc())


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/amp-demo/issues/35

## Issue
Duplicate items were showing when "Fastest Delivery" sort option was selected. This occurred regardless of whether a category filter was also applied.

## Root Cause
The backend API endpoint joins  and  tables for sorting purposes when `sort=delivery_fastest`. However, products with multiple delivery options create cartesian products from these joins, resulting in duplicate products in the query results.

## Solution
Added `.distinct()` to all three code paths in the `delivery_fastest` sorting logic to ensure each product appears only once in the results, regardless of how many delivery options it has.

## Testing
- ✅ All 51 backend tests pass
- ✅ All 34 E2E tests pass  
- ✅ Full CI pipeline passes (backend checks, frontend lint, build, E2E tests)

## Changes
- Modified `backend/app/main.py` to add `.distinct()` after sorting operations in the `delivery_fastest` sort paths

Amp-Thread-ID: https://ampcode.com/threads/T-1c9167c1-0cbc-4b9b-b484-7c6e780838a3