### PR TITLE
Fix #35: Prevent duplicate products in Fastest Delivery sort

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -231,6 +231,7 @@ def get_products_api(
                             ).asc(),
                             cast(ColumnElement[float], Product.price).asc(),
                         )
+                        .distinct()
                     )
                 else:
                     stmt = (
@@ -242,6 +243,7 @@ def get_products_api(
                             ).asc(),
                             cast(ColumnElement[float], Product.price).asc(),
                         )
+                        .distinct()
                     )
             else:
                 stmt = stmt.order_by(cast(ColumnElement, Product.created_at).desc())
@@ -253,6 +255,7 @@ def get_products_api(
                     cast(ColumnElement[int], DeliveryOption.estimated_days_min).asc(),
                     cast(ColumnElement[float], Product.price).asc(),
                 )
+                .distinct()
             )
     elif sort == "price_asc":
         stmt = stmt.order_by(cast(ColumnElement[float], Product.price).asc())


### PR DESCRIPTION
Fixes #35

## Problem
Duplicate items were showing when the Fastest Delivery sort option was selected. This occurred because the SQL query joins with the ProductDeliveryLink table, creating duplicate rows when a product has multiple delivery options.

## Solution
Added `.distinct()` to all `delivery_fastest` sorting queries to ensure each product appears exactly once in the results, regardless of how many delivery options it has.

## Testing
✅ All 51 backend tests pass
✅ All 34 E2E tests pass  
✅ All CI checks pass
✅ Tested with and without category filters
✅ Tested with and without delivery option filters

## Changes
Modified `/api/products` endpoint in `backend/app/main.py`:
- Added `.distinct()` when delivery filter is applied with express speed
- Added `.distinct()` when delivery filter is applied with other speeds  
- Added `.distinct()` when no delivery filter is applied

This ensures no duplicate products appear in any Fastest Delivery sorting scenario.